### PR TITLE
fix: drop axios dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "./src/*"
       ],
       "dependencies": {
-        "axios": "^0.27.2",
-        "axios-cookiejar-support": "^4.0.2",
         "jsdom": "^19.0.0",
         "set-cookie-parser": "^2.4.8",
         "tough-cookie": "^4.0.0"
@@ -90,30 +88,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-cookiejar-support": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-4.0.2.tgz",
-      "integrity": "sha512-IArUBLuuxjp3NnU/6kMN0xmhpr/+ECuVT7EKSUygATX5T+uWTypy9xaIRH8xjxTaNHv4upVcIpRmfoY5CoiJKA==",
-      "dependencies": {
-        "http-cookie-agent": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14.18.0 <15.0.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "axios": ">=0.20.0",
-        "tough-cookie": ">=4.0.0"
-      }
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -276,25 +250,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -317,30 +272,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/http-cookie-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-4.0.1.tgz",
-      "integrity": "sha512-9aCG7g3RSfplQLVT8qYX+qPS4bdCMo6Rx4gPLwTq1+iPahtNGLnUAmgz/kjvRP2XtrjdYoWc33lIaV0YYHa8JA==",
-      "dependencies": {
-        "agent-base": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=14.18.0 <15.0.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "deasync": "^0.1.26",
-        "tough-cookie": "^4.0.0",
-        "undici": "^5.1.1"
-      },
-      "peerDependenciesMeta": {
-        "deasync": {
-          "optional": true
-        },
-        "undici": {
-          "optional": true
-        }
       }
     },
     "node_modules/http-proxy-agent": {
@@ -744,23 +675,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "axios-cookiejar-support": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-4.0.2.tgz",
-      "integrity": "sha512-IArUBLuuxjp3NnU/6kMN0xmhpr/+ECuVT7EKSUygATX5T+uWTypy9xaIRH8xjxTaNHv4upVcIpRmfoY5CoiJKA==",
-      "requires": {
-        "http-cookie-agent": "^4.0.1"
-      }
-    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -878,11 +792,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
-    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -899,14 +808,6 @@
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "requires": {
         "whatwg-encoding": "^2.0.0"
-      }
-    },
-    "http-cookie-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-4.0.1.tgz",
-      "integrity": "sha512-9aCG7g3RSfplQLVT8qYX+qPS4bdCMo6Rx4gPLwTq1+iPahtNGLnUAmgz/kjvRP2XtrjdYoWc33lIaV0YYHa8JA==",
-      "requires": {
-        "agent-base": "^6.0.2"
       }
     },
     "http-proxy-agent": {
@@ -944,8 +845,6 @@
     "js-auth-test": {
       "version": "file:",
       "requires": {
-        "axios": "^0.27.2",
-        "axios-cookiejar-support": "^4.0.2",
         "js-auth-test": "file:",
         "jsdom": "^19.0.0",
         "set-cookie-parser": "^2.4.8",
@@ -1000,23 +899,6 @@
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
           "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        },
-        "axios-cookiejar-support": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-4.0.2.tgz",
-          "integrity": "sha512-IArUBLuuxjp3NnU/6kMN0xmhpr/+ECuVT7EKSUygATX5T+uWTypy9xaIRH8xjxTaNHv4upVcIpRmfoY5CoiJKA==",
-          "requires": {
-            "http-cookie-agent": "^4.0.1"
-          }
         },
         "browser-process-hrtime": {
           "version": "1.0.0",
@@ -1135,11 +1017,6 @@
           "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
           "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
-        "follow-redirects": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-          "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
-        },
         "form-data": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -1156,14 +1033,6 @@
           "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
           "requires": {
             "whatwg-encoding": "^2.0.0"
-          }
-        },
-        "http-cookie-agent": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-4.0.1.tgz",
-          "integrity": "sha512-9aCG7g3RSfplQLVT8qYX+qPS4bdCMo6Rx4gPLwTq1+iPahtNGLnUAmgz/kjvRP2XtrjdYoWc33lIaV0YYHa8JA==",
-          "requires": {
-            "agent-base": "^6.0.2"
           }
         },
         "http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.27.2",
-    "axios-cookiejar-support": "^4.0.2",
     "jsdom": "^19.0.0",
     "set-cookie-parser": "^2.4.8",
     "tough-cookie": "^4.0.0"


### PR DESCRIPTION
Refs: [CVE-2026-40175](https://nvd.nist.gov/vuln/detail/CVE-2026-40175)

`axios`, `axios-cookiejar-support` を削除。